### PR TITLE
Bitwise operators '&' and '|' should be used instead of logic operato…

### DIFF
--- a/src/nas/api/network/nas_message.c
+++ b/src/nas/api/network/nas_message.c
@@ -1054,9 +1054,9 @@ static int _nas_message_decrypt (
             OAILOG_FUNC_RETURN (LOG_NAS, 0);
           }
           if (direction == SECU_DIRECTION_UPLINK) {
-            count = 0x00000000 || ((emm_security_context->ul_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->ul_count.seq_num & 0x000000FF);
+            count = 0x00000000 | ((emm_security_context->ul_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->ul_count.seq_num & 0x000000FF);
           } else {
-            count = 0x00000000 || ((emm_security_context->dl_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->dl_count.seq_num & 0x000000FF);
+            count = 0x00000000 | ((emm_security_context->dl_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->dl_count.seq_num & 0x000000FF);
           }
 
           OAILOG_DEBUG (LOG_NAS,
@@ -1089,9 +1089,9 @@ static int _nas_message_decrypt (
             OAILOG_FUNC_RETURN (LOG_NAS, 0);
           }
           if (direction == SECU_DIRECTION_UPLINK) {
-            count = 0x00000000 || ((emm_security_context->ul_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->ul_count.seq_num & 0x000000FF);
+            count = 0x00000000 | ((emm_security_context->ul_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->ul_count.seq_num & 0x000000FF);
           } else {
-            count = 0x00000000 || ((emm_security_context->dl_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->dl_count.seq_num & 0x000000FF);
+            count = 0x00000000 | ((emm_security_context->dl_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->dl_count.seq_num & 0x000000FF);
           }
 
           OAILOG_DEBUG (LOG_NAS,
@@ -1209,9 +1209,9 @@ static int _nas_message_encrypt (
     switch (emm_security_context->selected_algorithms.encryption) {
     case NAS_SECURITY_ALGORITHMS_EEA1:{
         if (direction == SECU_DIRECTION_UPLINK) {
-          count = 0x00000000 || ((emm_security_context->ul_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->ul_count.seq_num & 0x000000FF);
+          count = 0x00000000 | ((emm_security_context->ul_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->ul_count.seq_num & 0x000000FF);
         } else {
-          count = 0x00000000 || ((emm_security_context->dl_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->dl_count.seq_num & 0x000000FF);
+          count = 0x00000000 | ((emm_security_context->dl_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->dl_count.seq_num & 0x000000FF);
         }
 
         OAILOG_DEBUG (LOG_NAS,
@@ -1234,9 +1234,9 @@ static int _nas_message_encrypt (
 
     case NAS_SECURITY_ALGORITHMS_EEA2:{
         if (direction == SECU_DIRECTION_UPLINK) {
-          count = 0x00000000 || ((emm_security_context->ul_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->ul_count.seq_num & 0x000000FF);
+          count = 0x00000000 | ((emm_security_context->ul_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->ul_count.seq_num & 0x000000FF);
         } else {
-          count = 0x00000000 || ((emm_security_context->dl_count.overflow && 0x0000FFFF) << 8) || (emm_security_context->dl_count.seq_num & 0x000000FF);
+          count = 0x00000000 | ((emm_security_context->dl_count.overflow & 0x0000FFFF) << 8) | (emm_security_context->dl_count.seq_num & 0x000000FF);
         }
 
         OAILOG_DEBUG (LOG_NAS,


### PR DESCRIPTION
Bit-wise operators '&' and '|' should be used instead of logic operators '&&' and '||'.